### PR TITLE
Corrected domain in manifest. 

### DIFF
--- a/custom_components/eufyrobovac/manifest.json
+++ b/custom_components/eufyrobovac/manifest.json
@@ -1,5 +1,5 @@
 {
-    "domain": "robovac",
+    "domain": "eufyrobovac",
     "name": "Eufy RoboVac",
     "documentation": "https://github.com/bnmcg/homeassistant-robovac",
     "dependencies": [],


### PR DESCRIPTION
Mismatching domain was causing problems in Home Assistant 0.96: dependencies weren't downloaded. Likely due to custom component config flows changes in 0.96. 